### PR TITLE
Tutorial 11_fractal fixed

### DIFF
--- a/doc/tutorial/11_fractal.cpp
+++ b/doc/tutorial/11_fractal.cpp
@@ -97,15 +97,15 @@ public:
         }
 
 #if !defined __native_client__
-        m_centertext = new Text(nullptr, "data/font/ascii.png");
+        m_centertext = new Text("", "data/font/ascii.png");
         m_centertext->SetPos(vec3(5, (float)m_window_size.y - 15, 1));
         Ticker::Ref(m_centertext);
 
-        m_mousetext = new Text(nullptr, "data/font/ascii.png");
+        m_mousetext = new Text("", "data/font/ascii.png");
         m_mousetext->SetPos(vec3(5, (float)m_window_size.y - 29, 1));
         Ticker::Ref(m_mousetext);
 
-        m_zoomtext = new Text(nullptr, "data/font/ascii.png");
+        m_zoomtext = new Text("", "data/font/ascii.png");
         m_zoomtext->SetPos(vec3(5, (float)m_window_size.y - 43, 1));
         Ticker::Ref(m_zoomtext);
 #endif


### PR DESCRIPTION
nullptr passed to string (through implicit cast) leads to app crash in tutorial 11, this commit avoid this crash.
