### PR TITLE
Crash fix: first call to TickGame must not occur before TickDraw

### DIFF
--- a/src/engine/ticker.cpp
+++ b/src/engine/ticker.cpp
@@ -504,7 +504,7 @@ void Ticker::Setup(float fps)
 
 #if LOL_FEATURE_THREADS
     data->gamethread = new thread(std::bind(&TickerData::GameThreadMain, data));
-    data->gametick.push(1);
+    data->drawtick.push(1);
 
     data->diskthread = new thread(std::bind(&TickerData::DiskThreadMain, data));
 #endif


### PR DESCRIPTION
closes #3
