### PR TITLE
Fix configure option '--disable-silent-rules' not working

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -14,9 +14,9 @@ AC_INIT(lolengine, 0.0)
 AC_PREREQ(2.50)
 AC_CONFIG_AUX_DIR(.auto)
 AC_CANONICAL_SYSTEM
+m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES([yes])])
 AM_INIT_AUTOMAKE([subdir-objects no-define tar-ustar silent-rules])
 dnl AM_MAINTAINER_MODE
-AM_DEFAULT_VERBOSITY=0
 
 dnl Versioning of the separate software we ship
 LOLUNIT_VERSION=0.1


### PR DESCRIPTION
The user applied **configure** option `--disable-silent-rules` should disable default silent rules.

Same as https://github.com/samhocevar/zepto8/pull/3